### PR TITLE
Prune event set after at least one processing iteration

### DIFF
--- a/event-processor/src/event_set.rs
+++ b/event-processor/src/event_set.rs
@@ -121,9 +121,6 @@ impl EventSet {
             return;
         }
 
-        // First remove any events that have outlived the TTL
-        self.prune_expired_events();
-
         for event in &mut self.events {
             info!("Processing event: {:?}", event.metadata);
 
@@ -189,6 +186,9 @@ impl EventSet {
                 error!("Failed to send archive event command, reason: {}", err);
             }
         }
+
+        // Now remove any events that have outlived the TTL
+        self.prune_expired_events();
 
         self.active_events.set(self.events.len() as i64);
 


### PR DESCRIPTION
This ensures events that new events that are added for some point in the past always get processed and the videos archived, before the event is pruned for being older than the TTL.