### PR TITLE
Handle restarting ffmpeg in agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2225,6 +2225,7 @@ dependencies = [
  "satori-common",
  "semver",
  "serde",
+ "serde_with",
  "tempfile",
  "tokio",
  "tower-http",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -14,6 +14,7 @@ regex.workspace = true
 satori-common.workspace = true
 semver.workspace = true
 serde.workspace = true
+serde_with.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["process"] }
 tower-http.workspace = true

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -1,16 +1,22 @@
-use crate::ffmpeg::StreamerConfig;
 use byte_unit::Byte;
 use serde::Deserialize;
+use serde_with::{serde_as, DurationSeconds};
 use std::{
     fs,
     path::{Path, PathBuf},
+    time::Duration,
 };
+use url::Url;
 
+#[serde_as]
 #[derive(Clone, Deserialize)]
 pub(crate) struct Config {
     pub(crate) video_directory: PathBuf,
 
-    pub(crate) stream: StreamerConfig,
+    pub(crate) stream: StreamConfig,
+
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub(crate) ffmpeg_restart_delay: Duration,
 }
 
 impl Config {
@@ -36,4 +42,14 @@ where
     }
 
     Ok(Byte::from_bytes(result))
+}
+
+#[derive(Clone, Deserialize)]
+pub(crate) struct StreamConfig {
+    pub(crate) url: Url,
+
+    pub(crate) ffmpeg_input_args: Vec<String>,
+
+    pub(crate) hls_segment_time: i32,
+    pub(crate) hls_retained_segment_count: i32,
 }

--- a/agent/src/ffmpeg/mod.rs
+++ b/agent/src/ffmpeg/mod.rs
@@ -3,16 +3,3 @@ pub(crate) use self::streamer::Streamer;
 
 mod version;
 pub(crate) use self::version::get_ffmpeg_version;
-
-use serde::Deserialize;
-use url::Url;
-
-#[derive(Clone, Deserialize)]
-pub(crate) struct StreamerConfig {
-    pub(crate) url: Url,
-
-    pub(crate) ffmpeg_input_args: Vec<String>,
-
-    pub(crate) hls_segment_time: i32,
-    pub(crate) hls_retained_segment_count: i32,
-}


### PR DESCRIPTION
Ensures that the HLS stream server remains accessible even if the camera is temporarily unavailable.

Closes #48 